### PR TITLE
Fix adjacent distinct

### DIFF
--- a/source/StreamConversions.h
+++ b/source/StreamConversions.h
@@ -69,7 +69,7 @@ private:
 
 struct PolymorphicHash {
     template<typename T>
-    decltype(auto) operator() (const T& value) {
+    decltype(auto) operator() (const T& value) const {
         return std::hash<T>{}(value);
     }
 };

--- a/source/providers/AdjacentDistinct.h
+++ b/source/providers/AdjacentDistinct.h
@@ -12,7 +12,7 @@ class AdjacentDistinct : public StreamProvider<T> {
 
 public:
     AdjacentDistinct(StreamProviderPtr<T> source, Equal&& equal)
-        : source_(std::move(source)), equal_(std::forward<Equal>(equal_)) {}
+        : source_(std::move(source)), equal_(std::forward<Equal>(equal)) {}
 
     std::shared_ptr<T> get() override {
         return current_;

--- a/test/AdjacentDistinctTest.cpp
+++ b/test/AdjacentDistinctTest.cpp
@@ -13,9 +13,25 @@ TEST(AdjacentDistinctTest, Default) {
                 ElementsAre(1, 2, 1, 3));
 }
 
-TEST(AdjacentDistinctTest, WithEquals) {
+TEST(AdjacentDistinctTest, WithEqualsUsingLambda) {
     EXPECT_THAT(MakeStream::from({1, 2, 5, 10, 0, 8, 12, -1, 3, 5})
                     | adjacent_distinct([](int x, int y) { return x < y; })
+                    | to_vector(),
+                ElementsAre(1, 0, -1));
+}
+
+TEST(AdjacentDistinctTest, WithEqualsUsingStaticFunction) {
+    /* Specific test using a real function instead of lambda, as the compiler
+     * does not handle them in the same way (may work with lambda not with
+     * real function) */
+    struct Dummy {
+        static bool compare(int x, int y) {
+            return x < y;
+        }
+    };
+
+    EXPECT_THAT(MakeStream::from({1, 2, 5, 10, 0, 8, 12, -1, 3, 5})
+                    | adjacent_distinct(Dummy::compare)
                     | to_vector(),
                 ElementsAre(1, 0, -1));
 }


### PR DESCRIPTION
Sadly, the code of AdjacentDistinct was wrong.

This merge request fixes compilation on clang 4.0.1 and the AdjacentDistinct class (update the unit test to track the original bug)